### PR TITLE
Standard http.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,12 @@ Two, it downloads upcoming chunks in parallel, so if the parallelism count is se
 
 The lowest-level usage is to create a new `Ranger` with chunk size and parallelism, and a fetcher function passed in. When the `Ranger` is invoked with a file length, it calls the fetch function with the byte range, in parallel, and collects and orders the resulting chunk Readers. This is a low level API that you can use if you have a custom protocol to fetch data. 
 
-For regular use, Ranger provides an `HTTPClient` wrapper that wraps any other `HTTPClient`. Calls made to `GET` files will use the wrapped client to check file length using a `HEAD` request, and then range over the chunks using the given chunk size and parallelism parameters.
+For regular use, `RangingHTTPClient` uses a given `http.Client` to fetch chunks
+as configured. `RangingHTTPClient` also exposes a standard `http.Client` via the
+`RangingHTTPClient.StandardClient` method. The returned client will fetch chunk
+ranges using the `RangingHTTPClient`.
 
-This means that Ranger integrates well on both sides - it can be passed as a custom `HTTPClient` to download managers like [Grab](https://github.com/cavaliergopher/grab), while wrapping other `HTTPClient`s that provide automatic retry and other features like [Heimdall](https://github.com/gojek/heimdall) or [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp).
-
-
-
-
-
-
-
-
-
-
-
+This means that Ranger integrates well on both sides - [Grab](https://github.com/cavaliergopher/grab)
+and other download managers can use a ranging client via a standard `http.Client`,
+while wrapping other `HTTPClient`s that provide automatic retry, etc
+like [Heimdall](https://github.com/gojek/heimdall) or [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RANGER
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/sudhirj/ranger.svg)](https://pkg.go.dev/github.com/sudhirj/ranger)
+
 *Download large files in parallel chunks in Go.*
 
 ### Why? 

--- a/http_test.go
+++ b/http_test.go
@@ -58,10 +58,10 @@ func TestOffsetDownload(t *testing.T) {
 	}
 }
 
-func testClients() []HTTPClient {
-	return []HTTPClient{
-		NewRangingClient(NewRanger(1000), http.DefaultClient, 3),
-		NewRangingClient(NewRanger(1000), http.DefaultClient, 1),
+func testClients() []*http.Client {
+	return []*http.Client{
+		NewRangingClient(NewRanger(1000), http.DefaultClient, 3).StandardClient(),
+		NewRangingClient(NewRanger(1000), http.DefaultClient, 1).StandardClient(),
 		http.DefaultClient,
 	}
 }

--- a/ranger.go
+++ b/ranger.go
@@ -1,11 +1,20 @@
 package ranger
 
+const (
+	defaultChunkSize = 1024 * 1024 // 1MB
+)
+
 // Ranger can split a file into chunks of a given size.
 type Ranger struct {
 	chunkSize int64
 }
 
+// NewRanger creates a new Ranger with the given chunk size.
+// If the chunk size is <= 0, the default chunk size is used.
 func NewRanger(chunkSize int64) Ranger {
+	if chunkSize <= 0 {
+		chunkSize = defaultChunkSize
+	}
 	return Ranger{chunkSize: chunkSize}
 }
 


### PR DESCRIPTION
RangingHTTPClient can be used via a standard `http.Client` for broad compatibility.